### PR TITLE
Couple of small fixes for ELK stack

### DIFF
--- a/irods_audit_elk_stack/Dockerfile
+++ b/irods_audit_elk_stack/Dockerfile
@@ -133,6 +133,7 @@ RUN rabbitmq-plugins enable \
         rabbitmq_amqp1_0 \
         rabbitmq_management \
     && \
+    echo 'NODENAME=rabbitmq@localhost' > /etc/rabbitmq/rabbitmq-env.conf && \
     /etc/init.d/rabbitmq-server start && \
     rabbitmqctl add_user test test && \
     rabbitmqctl set_user_tags test administrator && \

--- a/irods_audit_elk_stack/Dockerfile
+++ b/irods_audit_elk_stack/Dockerfile
@@ -49,13 +49,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # Install JDK/JRE
 COPY java-excludes.dpkg.cfg /etc/dpkg/dpkg.cfg.d/java-excludes
 ADD https://packages.adoptium.net/artifactory/api/gpg/key/public /usr/share/keyrings/adoptium.asc
-ADD https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public /usr/share/keyrings/adoptopenjdk.asc
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     gpg --dearmor -o /usr/share/keyrings/adoptium.gpg /usr/share/keyrings/adoptium.asc && \
-    gpg --dearmor -o /usr/share/keyrings/adoptopenjdk.gpg /usr/share/keyrings/adoptopenjdk.asc && \
     echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list && \
-    echo "deb [signed-by=/usr/share/keyrings/adoptopenjdk.gpg] https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptopenjdk.list && \
     apt-get update && \
     apt-get install -y \
         adoptium-ca-certificates \


### PR DESCRIPTION
- Removed AdoptOpenJDK repo since it is unused and goes down frequently.
- Set `NODENAME` in `rabbitmq-env.conf` (#33)
